### PR TITLE
Add raw container mode to PSI scripts

### DIFF
--- a/psi/steps-to-use
+++ b/psi/steps-to-use
@@ -5,7 +5,8 @@ Step 2: Each party prepares their data.
 Server:
   ./prepare_intersection.py --role server --input server_list.txt \
       --client-size <client-list-size> --state server_state.json \
-      --out server_setup.txt
+      --out server_setup.txt [--ds raw]
+  # Use ``--ds raw`` to disable probabilistic matching.
 Client:
   ./prepare_intersection.py --role client --input client_list.txt \
       --state client_state.json --out client_request.txt

--- a/psi/technical-design-doc.md
+++ b/psi/technical-design-doc.md
@@ -39,7 +39,7 @@ protocol with reversed roles.
 - **State files** are JSON objects with fields:
   - `role`: `"server"` or `"client"`
   - `priv`: base64 encoded private key bytes
-  - For servers, also `client_size` and `fpr` used to generate the setup message.
+  - For servers, also `client_size`, `fpr` and the chosen data structure (`ds`) used to generate the setup message.
 - **Blob files** contain a single base64 encoded string representing the
   serialized protobuf message (`ServerSetup`, `Request` or `Response`).
 
@@ -48,6 +48,9 @@ protocol with reversed roles.
   delete them after use.
 - The chosen false positive rate (`fpr`) controls the probability of spurious
   matches. A value of `1e-6` is used by default.
+- The data structure can be `gcs` (Golomb Compressed Sets) or `raw`. Using
+  `raw` avoids any possibility of false positives at the cost of larger
+  messages.
 - The protocol assumes semi-honest participants and does not hide the client
   set size.
 

--- a/psi/tests/test_psi.py
+++ b/psi/tests/test_psi.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import tempfile
+import pytest
 
 ROOT = os.path.dirname(os.path.dirname(__file__))
 PREP = os.path.join(ROOT, 'prepare_intersection.py')
@@ -11,13 +12,16 @@ def run(cmd):
     subprocess.check_call(cmd, shell=True)
 
 
-def test_end_to_end(tmp_path):
+@pytest.mark.parametrize("ds", ["gcs", "raw"])
+def test_end_to_end(tmp_path, ds):
     server_list = tmp_path / 'server.txt'
     server_list.write_text('apple\nbanana\ncarrot\n')
     client_list = tmp_path / 'client.txt'
     client_list.write_text('banana\ndate\n')
 
-    run(f"{PREP} --role server --input {server_list} --client-size 2 --state {tmp_path/'s_state.json'} --out {tmp_path/'setup.txt'}")
+    run(
+        f"{PREP} --role server --input {server_list} --client-size 2 --state {tmp_path/'s_state.json'} --out {tmp_path/'setup.txt'} --ds {ds}"
+    )
     run(f"{PREP} --role client --input {client_list} --state {tmp_path/'c_state.json'} --out {tmp_path/'request.txt'}")
 
     run(f"{FIND} --role server --state {tmp_path/'s_state.json'} --inblob {tmp_path/'request.txt'} --out {tmp_path/'response.txt'}")


### PR DESCRIPTION
## Summary
- allow choosing Golomb Compressed Set or Raw container
- update docs with new `--ds` option
- extend tests to exercise both data-structure modes

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6877ff8c034c83248ab9c9239275b5d0