### PR TITLE
Import list-of-type? and alist? from MIT Scheme runtime

### DIFF
--- a/iasylum/iasylum.scm
+++ b/iasylum/iasylum.scm
@@ -153,6 +153,8 @@
    amb-possibility-list
    alist-swap
    -to_
+   list-of-type?
+   alist?
    )
 
   ;; This makes scm scripts easier in the eyes of non-schemers.


### PR DESCRIPTION
This change incorporates the MIT Scheme runtime implementation of list-of-type?, which validates that a list’s elements satisfy a given predicate while safely handling improper and circular lists via cycle detection.

Using this implementation avoids non-terminating traversals that can occur with naïve recursive predicates. For example, a circular list such as:

`  (let ((x (list 1 2 3))) (set-cdr! (cddr x) x) x)`

will be rejected deterministically instead of looping forever.

The alist? predicate is defined in terms of list-of-type?, ensuring that association lists are validated correctly and consistently with MIT Scheme semantics.

Example usage:

```
  (list-of-type? '(1 2 3) number?)        ; => #t
  (list-of-type? '(1 2 a) number?)        ; => #f
  (list-of-type? '(1 2 . 3) number?)      ; => #f
```

The alist? predicate is defined as a specialization:

```
  (alist? '((a . 1) (b . 2)))             ; => #t
  (alist? '((a . 1) b (c . 3)))           ; => #f
```